### PR TITLE
Fix the Group class calling the raw_ptr () function returns a value of NULL

### DIFF
--- a/src/lvglpp/core/group.cpp
+++ b/src/lvglpp/core/group.cpp
@@ -10,6 +10,10 @@
 
 namespace lvgl::core {
 
+     Group::Group() {
+        this->lv_obj=LvPointerType(lv_group_create());
+    }
+
     void Group::set_default() {
         lv_group_set_default(this->raw_ptr());
     }

--- a/src/lvglpp/core/group.h
+++ b/src/lvglpp/core/group.h
@@ -18,6 +18,8 @@ namespace lvgl::core {
     public:
         using PointerWrapper::PointerWrapper;
         
+
+         Group();
         /** \fn void set_default()
          *  \brief Sets group as default group for new objects.
          */


### PR DESCRIPTION
I raised this question in issue before, I thought it was the problem of smart pointer, but I didn't make any lvgl-related function calls. I modified it, and now it's running normally, and my test is valid.